### PR TITLE
Prepare v0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-Unreleased
+0.0.6
 -----
 
 - Disallow Google-CloudVertexBot

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bonniernews/no-ai-robots",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bonniernews/no-ai-robots",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "Apache-2.0",
       "devDependencies": {
         "@bonniernews/eslint-config": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonniernews/no-ai-robots",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Express middleware for blocking ai-robots",
   "main": "index.js",
   "homepage": "https://github.com/BonnierNews/no-ai-robots",
@@ -12,9 +12,7 @@
   "scripts": {
     "build": "node scripts/build.js > index.js",
     "prepack": "npm run build",
-    "lint": "eslint .",
-    "postpublish": "npm run publish-internal",
-    "publish-internal": "npm publish --access public --ignore-scripts --@bonniernews:registry='https://npm.pkg.github.com'"
+    "lint": "eslint ."
   },
   "author": "Bonnier News AB",
   "license": "Apache-2.0",


### PR DESCRIPTION
Version 0.0.6
I removed the internal publishing to private github package since this is not used. If necessary we should switch to an entirely private package under `@bonniernews-internal` on shared artifacts.